### PR TITLE
ci: deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/callout/',
   plugins: [react()],
   define: {
     global: 'globalThis',


### PR DESCRIPTION
## Changes

- Add GitHub Actions workflow for automatic deployment to GitHub Pages on push to main
- Set Vite `base` path to `/callout/` for subpath hosting

## Result

After merge, the app will be live at: **https://moltmorbius.github.io/callout/**

The workflow runs on every push to `main` and can also be triggered manually via `workflow_dispatch`.

## Note

⚠️ **CEO Action Item:** No Reown project ID (`VITE_REOWN_PROJECT_ID`) found in 1Password. The app will build with the fallback `demo-project-id`, but wallet connections won't work properly until a real project ID is set. Get one from https://cloud.reown.com and add it as a GitHub repository secret.