### PR TITLE
Fix: Blank white screen on mobile

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,92 @@
+import { Component, type ReactNode } from 'react'
+import { Box, Text, Button, VStack, Code } from '@chakra-ui/react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+    console.error('[Callout] React error boundary caught:', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box
+          minH="100vh"
+          bg="#06060f"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          p={6}
+        >
+          <VStack spacing={5} maxW="480px" textAlign="center">
+            <Text fontSize="4xl">⚠️</Text>
+            <Text
+              fontSize="xl"
+              fontWeight="800"
+              color="red.300"
+              letterSpacing="0.05em"
+            >
+              Something went wrong
+            </Text>
+            <Text fontSize="sm" color="whiteAlpha.500" lineHeight="1.7">
+              The app encountered an unexpected error. This may be due to a
+              network issue or browser incompatibility. Try refreshing the page.
+            </Text>
+            {this.state.error && (
+              <Code
+                display="block"
+                p={3}
+                borderRadius="lg"
+                fontSize="xs"
+                bg="rgba(6, 6, 15, 0.9)"
+                border="1px solid"
+                borderColor="whiteAlpha.100"
+                color="whiteAlpha.400"
+                fontFamily="mono"
+                maxW="100%"
+                overflowX="auto"
+                whiteSpace="pre-wrap"
+                wordBreak="break-all"
+              >
+                {this.state.error.message}
+              </Code>
+            )}
+            <Button
+              onClick={() => window.location.reload()}
+              bg="rgba(220, 38, 38, 0.15)"
+              color="red.300"
+              border="1px solid"
+              borderColor="rgba(220, 38, 38, 0.3)"
+              borderRadius="xl"
+              fontWeight="700"
+              _hover={{
+                bg: 'rgba(220, 38, 38, 0.25)',
+              }}
+            >
+              Reload Page
+            </Button>
+          </VStack>
+        </Box>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ export function Header() {
       py={3}
     >
       <Flex justify="space-between" align="center" maxW="960px" mx="auto">
-        <HStack spacing={3} align="center">
+        <HStack spacing={3} align="center" minW={0} flex={1}>
           {/* Crosshair icon with pulse */}
           <Box
             w="40px"
@@ -62,7 +62,7 @@ export function Header() {
             </Text>
           </Box>
         </HStack>
-        <Box>
+        <Box flexShrink={0}>
           <appkit-button />
         </Box>
       </Flex>

--- a/src/config/web3.ts
+++ b/src/config/web3.ts
@@ -34,25 +34,32 @@ export const wagmiAdapter = new WagmiAdapter({
   networks,
 })
 
-export const appKit = createAppKit({
-  adapters: [wagmiAdapter],
-  networks,
-  projectId,
-  metadata: {
-    name: 'Callout',
-    description: 'Put scammers on blast. On-chain. Forever.',
-    url: 'https://callout.city',
-    icons: ['https://callout.city/icon.png'],
-  },
-  themeMode: 'dark',
-  themeVariables: {
-    '--w3m-color-mix': '#1a1a2e',
-    '--w3m-color-mix-strength': 20,
-    '--w3m-accent': '#e74c3c',
-  },
-})
+// Initialize AppKit in a try/catch so a bad project ID or network error
+// doesn't crash the entire module import chain and blank the screen.
+let appKit: ReturnType<typeof createAppKit> | null = null
+try {
+  appKit = createAppKit({
+    adapters: [wagmiAdapter],
+    networks,
+    projectId,
+    metadata: {
+      name: 'Callout',
+      description: 'Put scammers on blast. On-chain. Forever.',
+      url: 'https://callout.city',
+      icons: ['https://callout.city/icon.png'],
+    },
+    themeMode: 'dark',
+    themeVariables: {
+      '--w3m-color-mix': '#1a1a2e',
+      '--w3m-color-mix-strength': 20,
+      '--w3m-accent': '#e74c3c',
+    },
+  })
+} catch (err) {
+  console.error('[Callout] AppKit initialization failed:', err)
+}
 
-export { pulsechain }
+export { appKit, pulsechain }
 
 // Explorer URLs by chain ID
 export const explorerUrls: Record<number, string> = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// Polyfills must be loaded before anything else
+import './polyfills'
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
@@ -5,19 +8,30 @@ import { WagmiProvider } from 'wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import theme from './config/theme'
 import { wagmiAdapter } from './config/web3'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import App from './App'
 
 const queryClient = new QueryClient()
 
+// Catch unhandled promise rejections (e.g. from AppKit network calls)
+// so they don't crash the page on mobile
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[Callout] Unhandled promise rejection:', event.reason)
+  // Prevent the browser from treating this as a fatal error
+  event.preventDefault()
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-    <WagmiProvider config={wagmiAdapter.wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        <ChakraProvider theme={theme}>
-          <App />
-        </ChakraProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <ErrorBoundary>
+      <WagmiProvider config={wagmiAdapter.wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <ChakraProvider theme={theme}>
+            <App />
+          </ChakraProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,10 @@
+/**
+ * Polyfills required for WalletConnect / @reown/appkit on mobile browsers.
+ * Must be imported BEFORE any web3 modules.
+ */
+import { Buffer } from 'buffer'
+
+// Make Buffer available globally (WalletConnect internals expect it)
+if (typeof globalThis.Buffer === 'undefined') {
+  globalThis.Buffer = Buffer
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
   define: {
     global: 'globalThis',
   },
+  resolve: {
+    alias: {
+      buffer: 'buffer',
+    },
+  },
+  optimizeDeps: {
+    include: ['buffer'],
+  },
   server: {
     port: 5199,
     host: '0.0.0.0',


### PR DESCRIPTION
## Problem

Blank white screen on mobile when visiting the Callout app. The React app fails to mount entirely.

### Root Causes Found

1. **`createAppKit()` crashes at module level** — Reown AppKit initialization runs as a top-level side effect in `src/config/web3.ts`. If the project ID is invalid or a network call fails (403 from `api.web3modal.org`), the entire module import chain fails and React never mounts.

2. **No Buffer polyfill** — WalletConnect internals expect `globalThis.Buffer` which doesn't exist in mobile browsers. The `buffer` package was in dependencies but never actually imported or assigned globally.

3. **No error boundary** — Any uncaught error during initialization or rendering produces a blank white screen with zero feedback.

4. **Unhandled promise rejections** — Async errors from AppKit network calls (e.g. bad project ID → 403) go unhandled and can crash mobile browsers.

## Fixes

### Core — blank screen prevention
- **`src/config/web3.ts`** — Wrapped `createAppKit()` in try/catch. Initialization can now fail gracefully without crashing the module import chain. `appKit` is exported as nullable.
- **`src/components/ErrorBoundary.tsx`** — New React error boundary with styled fallback UI (error message + reload button). Catches any rendering errors.
- **`src/polyfills.ts`** — New file. Imports `buffer` and sets `globalThis.Buffer` before any web3 modules load.
- **`src/main.tsx`** — Imports polyfills first, wraps app in ErrorBoundary, adds `unhandledrejection` handler to catch async errors from AppKit.

### Mobile responsiveness
- **`src/components/Header.tsx`** — Added `minW={0}`, `flex={1}` on logo HStack to allow shrinking on narrow screens. Added `flexShrink={0}` on wallet button container to prevent it from being crushed.

### Build config
- **`vite.config.ts`** — Added `buffer` to `resolve.alias` and `optimizeDeps.include` for proper bundling.

## Files Changed (6)
- `src/config/web3.ts` — try/catch around createAppKit(), nullable export
- `src/main.tsx` — polyfill import, ErrorBoundary wrapper, unhandledrejection handler
- `src/components/ErrorBoundary.tsx` — **NEW**: React error boundary
- `src/polyfills.ts` — **NEW**: Buffer polyfill for mobile browsers
- `src/components/Header.tsx` — mobile flex layout fix
- `vite.config.ts` — buffer resolve alias and optimizeDeps

## Verification
- `npm run build` passes with 0 errors
- Built bundle contains try/catch, ErrorBoundary, and Buffer polyfill
- No workflow or deployment files modified — Railway handles env vars