### PR TITLE
ci: add guard-main branch protection

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,21 @@
+name: Guard Main Branch
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  check-author:
+    name: Block bot direct pushes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject direct push from bot
+        if: github.actor == 'clawdmorbius'
+        run: |
+          echo "❌ Direct push to main by clawdmorbius is not allowed."
+          echo "Please create a PR and get CEO approval before merging."
+          exit 1
+
+      - name: Allow
+        if: github.actor != 'clawdmorbius'
+        run: echo "✅ Push by ${{ github.actor }} allowed."


### PR DESCRIPTION
Adds the same `guard-main` workflow used on belt, belt-landing, and belt-tests. Blocks direct pushes to main from clawdmorbius — all changes must go through PRs.