### PR TITLE
fix: use IPFS PulseChain explorer URL

### DIFF
--- a/src/config/web3.ts
+++ b/src/config/web3.ts
@@ -64,7 +64,7 @@ export { appKit, pulsechain }
 // Explorer URLs by chain ID
 export const explorerUrls: Record<number, string> = {
   1: 'https://etherscan.io',
-  369: 'https://scan.pulsechain.com',
+  369: 'https://ipfs.scan.pulsechain.com',
   137: 'https://polygonscan.com',
   42161: 'https://arbiscan.io',
   10: 'https://optimistic.etherscan.io',


### PR DESCRIPTION
Replaces `scan.pulsechain.com` with the IPFS-hosted explorer at `scan.mypinata.cloud/ipfs/...`. The IPFS gateway forwards path patterns, serving the block explorer as a decentralized SPA.