### PR TITLE
fix: align templates.test.ts with MessageTemplate type

### DIFF
--- a/src/config/templates.test.ts
+++ b/src/config/templates.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { messageTemplates, applyTemplate, type MessageTone } from './templates'
+import {
+  messageTemplates,
+  templateCategories,
+  applyTemplate,
+  extractVariableKeys,
+  getTemplatesByCategory,
+  getTemplateById,
+  type MessageTemplate,
+  type TemplateCategoryId,
+} from './templates'
 
 describe('messageTemplates', () => {
   it('has at least one template', () => {
@@ -8,70 +17,117 @@ describe('messageTemplates', () => {
 
   it('every template has required fields', () => {
     for (const tpl of messageTemplates) {
-      expect(tpl.tone).toBeTruthy()
-      expect(tpl.label).toBeTruthy()
-      expect(tpl.color).toBeTruthy()
+      expect(tpl.id).toBeTruthy()
+      expect(tpl.name).toBeTruthy()
+      expect(tpl.categoryId).toBeTruthy()
       expect(tpl.emoji).toBeTruthy()
       expect(tpl.template).toBeTruthy()
       expect(tpl.description).toBeTruthy()
+      expect(Array.isArray(tpl.variables)).toBe(true)
     }
   })
 
-  it('every template uses [address] placeholder', () => {
+  it('every template uses ${variable} placeholder syntax', () => {
     for (const tpl of messageTemplates) {
-      expect(tpl.template).toContain('[address]')
+      expect(tpl.template).toMatch(/\$\{\w+\}/)
     }
   })
 
-  it('has unique tone values', () => {
-    const tones = messageTemplates.map((t) => t.tone)
-    expect(new Set(tones).size).toBe(tones.length)
+  it('has unique id values', () => {
+    const ids = messageTemplates.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
   })
 
-  it('tones are valid MessageTone values', () => {
-    const validTones: MessageTone[] = ['cordial', 'firm', 'hostile', 'custom']
+  it('every template references a valid category', () => {
+    const validCategoryIds = templateCategories.map((c) => c.id)
     for (const tpl of messageTemplates) {
-      expect(validTones).toContain(tpl.tone)
+      expect(validCategoryIds).toContain(tpl.categoryId)
     }
   })
 
-  it('has the expected three tones: cordial, firm, hostile', () => {
-    const tones = messageTemplates.map((t) => t.tone)
-    expect(tones).toContain('cordial')
-    expect(tones).toContain('firm')
-    expect(tones).toContain('hostile')
+  it('has templates in all defined categories', () => {
+    for (const cat of templateCategories) {
+      const templates = getTemplatesByCategory(cat.id)
+      expect(templates.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('template variables match placeholders in template string', () => {
+    for (const tpl of messageTemplates) {
+      const placeholderKeys = extractVariableKeys(tpl.template)
+      const varKeys = tpl.variables.map((v) => v.key)
+      for (const key of placeholderKeys) {
+        expect(varKeys).toContain(key)
+      }
+    }
   })
 })
 
 describe('applyTemplate', () => {
-  it('replaces [address] with the given address', () => {
-    const template = 'Send funds to [address] immediately.'
-    const result = applyTemplate(template, '0xDeAd...BeEf')
+  it('replaces ${key} with the given value', () => {
+    const template = 'Send funds to ${receive_address} immediately.'
+    const result = applyTemplate(template, { receive_address: '0xDeAd...BeEf' })
     expect(result).toBe('Send funds to 0xDeAd...BeEf immediately.')
   })
 
-  it('replaces multiple [address] occurrences', () => {
-    const template = 'From [address] to [address]'
-    const result = applyTemplate(template, '0x1234')
-    expect(result).toBe('From 0x1234 to 0x1234')
+  it('replaces multiple different placeholders', () => {
+    const template = 'From ${exploited_address} stolen ${amount} ${token_name}'
+    const result = applyTemplate(template, {
+      exploited_address: '0x1234',
+      amount: '100',
+      token_name: 'ETH',
+    })
+    expect(result).toBe('From 0x1234 stolen 100 ETH')
   })
 
-  it('falls back to [address] when empty string is provided', () => {
-    const template = 'Send to [address]'
-    const result = applyTemplate(template, '')
-    expect(result).toBe('Send to [address]')
+  it('falls back to [key] when empty string is provided', () => {
+    const template = 'Send to ${receive_address}'
+    const result = applyTemplate(template, { receive_address: '' })
+    expect(result).toBe('Send to [receive_address]')
+  })
+
+  it('falls back to [key] when variable is missing', () => {
+    const template = 'Send to ${receive_address}'
+    const result = applyTemplate(template, {})
+    expect(result).toBe('Send to [receive_address]')
   })
 
   it('works with actual templates from the array', () => {
     const tpl = messageTemplates[0]
-    const result = applyTemplate(tpl.template, '0xABCD')
-    expect(result).not.toContain('[address]')
-    expect(result).toContain('0xABCD')
+    const values: Record<string, string> = {}
+    for (const v of tpl.variables) {
+      values[v.key] = '0xABCD'
+    }
+    const result = applyTemplate(tpl.template, values)
+    expect(result).not.toMatch(/\[(\w+)\]/)
   })
 
-  it('leaves template unchanged if no [address] placeholder', () => {
+  it('leaves template unchanged if no placeholders', () => {
     const template = 'No placeholder here.'
-    const result = applyTemplate(template, '0x1234')
+    const result = applyTemplate(template, { receive_address: '0x1234' })
     expect(result).toBe('No placeholder here.')
+  })
+})
+
+describe('getTemplateById', () => {
+  it('finds a template by id', () => {
+    const tpl = getTemplateById('scam-bounty')
+    expect(tpl).toBeDefined()
+    expect(tpl!.name).toBe('White Hat Bounty Offer')
+  })
+
+  it('returns undefined for unknown id', () => {
+    expect(getTemplateById('nonexistent')).toBeUndefined()
+  })
+})
+
+describe('extractVariableKeys', () => {
+  it('extracts unique keys from a template string', () => {
+    const keys = extractVariableKeys('${a} and ${b} and ${a}')
+    expect(keys).toEqual(['a', 'b'])
+  })
+
+  it('returns empty array when no placeholders', () => {
+    expect(extractVariableKeys('no vars')).toEqual([])
   })
 })


### PR DESCRIPTION
## Problem
The Deploy to GitHub Pages workflow broke after merging PR #12 (feat/template-messages). The test file `src/config/templates.test.ts` was written against an older type shape that no longer exists.

### Errors fixed
- `Property 'tone' does not exist on type 'MessageTemplate'`
- `Property 'label' does not exist on type 'MessageTemplate'`
- `Property 'color' does not exist on type 'MessageTemplate'`
- `'"cordial"' is not assignable to type '"custom"'`
- `Argument of type 'string' is not assignable to parameter of type 'Record<string, string>'`

## Fix
Rewrote the tests to match the actual `MessageTemplate` type:
- Test `id`, `name`, `categoryId`, `emoji`, `template`, `description`, `variables` fields
- Use `${variable}` placeholder syntax instead of `[address]`
- Pass `Record<string, string>` to `applyTemplate()` instead of a bare string
- Added tests for `getTemplateById`, `extractVariableKeys`, and category validation

## Verification
```bash
npx tsc --noEmit     # ✅ zero errors
npx vitest run src/config/templates.test.ts  # ✅ 17/17 pass
```