### PR TITLE
feat: replace appkit-button with custom Chakra UI wallet buttons

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,20 @@
-import { Box, Flex, Text, HStack } from '@chakra-ui/react'
+import { Box, Flex, Text, HStack, Button } from '@chakra-ui/react'
 import { keyframes } from '@emotion/react'
+import { useAppKit, useAppKitAccount } from '@reown/appkit/react'
 
 const pulseGlow = keyframes`
   0%, 100% { box-shadow: 0 0 8px rgba(220, 38, 38, 0.3); }
   50% { box-shadow: 0 0 16px rgba(220, 38, 38, 0.5), 0 0 30px rgba(220, 38, 38, 0.15); }
 `
 
+function truncateAddress(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`
+}
+
 export function Header() {
+  const { open } = useAppKit()
+  const { address, isConnected } = useAppKitAccount()
+
   return (
     <Box
       position="sticky"
@@ -63,7 +71,27 @@ export function Header() {
           </Box>
         </HStack>
         <Box flexShrink={0}>
-          <appkit-button />
+          <Button
+            size="sm"
+            px={4}
+            fontWeight="700"
+            fontSize="xs"
+            letterSpacing="0.04em"
+            fontFamily={isConnected ? 'mono' : 'body'}
+            bg={isConnected ? 'rgba(220, 38, 38, 0.12)' : 'rgba(220, 38, 38, 0.85)'}
+            color={isConnected ? 'red.300' : 'white'}
+            border="1px solid"
+            borderColor={isConnected ? 'rgba(220, 38, 38, 0.3)' : 'rgba(220, 38, 38, 0.6)'}
+            borderRadius="lg"
+            _hover={{
+              bg: isConnected ? 'rgba(220, 38, 38, 0.2)' : 'red.600',
+              borderColor: 'rgba(220, 38, 38, 0.5)',
+            }}
+            _active={{ bg: isConnected ? 'rgba(220, 38, 38, 0.25)' : 'red.700' }}
+            onClick={() => open()}
+          >
+            {isConnected && address ? truncateAddress(address) : 'Connect Wallet'}
+          </Button>
         </Box>
       </Flex>
     </Box>

--- a/src/components/MessageComposer.tsx
+++ b/src/components/MessageComposer.tsx
@@ -20,6 +20,7 @@ import {
   SimpleGrid,
 } from '@chakra-ui/react'
 import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useAppKit } from '@reown/appkit/react'
 import { useAccount, useEstimateGas, useSendTransaction, useChainId } from 'wagmi'
 import { type Address, isAddress, parseEther } from 'viem'
 import { keyframes } from '@emotion/react'
@@ -99,6 +100,7 @@ const categoryColors: Record<string, {
 }
 
 export function MessageComposer() {
+  const { open } = useAppKit()
   const { isConnected, address: walletAddress } = useAccount()
   const chainId = useChainId()
   const toast = useToast()
@@ -291,9 +293,28 @@ export function MessageComposer() {
         <Text fontSize="sm" color="whiteAlpha.300" mb={6} maxW="280px" mx="auto" lineHeight="1.6">
           Connect your wallet to start sending on-chain messages
         </Text>
-        <Box display="inline-block">
-          <appkit-button />
-        </Box>
+        <Button
+          size="lg"
+          px={8}
+          fontWeight="800"
+          fontSize="sm"
+          letterSpacing="0.06em"
+          bg="rgba(220, 38, 38, 0.85)"
+          color="white"
+          border="1px solid"
+          borderColor="rgba(220, 38, 38, 0.6)"
+          borderRadius="xl"
+          _hover={{
+            bg: 'red.600',
+            transform: 'translateY(-1px)',
+            boxShadow: '0 4px 20px rgba(220, 38, 38, 0.3)',
+          }}
+          _active={{ bg: 'red.700', transform: 'translateY(0)' }}
+          transition="all 0.2s"
+          onClick={() => open()}
+        >
+          Connect Wallet
+        </Button>
       </Box>
     )
   }

--- a/src/types/appkit.d.ts
+++ b/src/types/appkit.d.ts
@@ -1,11 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
-import type { JSX as ReactJSX } from 'react'
+// Reown AppKit — custom web-component type declarations
+// (appkit-button removed: replaced with native Chakra UI buttons)
 
-declare module 'react' {
-  namespace JSX {
-    interface IntrinsicElements {
-      'appkit-button': ReactJSX.IntrinsicElements['div'] & Record<string, unknown>
-      'appkit-network-button': ReactJSX.IntrinsicElements['div'] & Record<string, unknown>
-    }
-  }
-}
+export {}


### PR DESCRIPTION
## Summary

Replace all `<appkit-button />` web components with custom styled Chakra UI `<Button>` components that call Reown's programmatic `open()` method. This gives full control over button styling and appearance.

## Changes

### Header.tsx
- Import `useAppKit` and `useAppKitAccount` from `@reown/appkit/react`
- Replace `<appkit-button />` with a compact Chakra UI `<Button>`
- Shows **'Connect Wallet'** when disconnected
- Shows **truncated address** (`0x1234…5678`) in mono font when connected
- Clicking opens the Reown modal (connect/disconnect/switch network)
- Styled with the app's red accent dark theme

### MessageComposer.tsx
- Import `useAppKit` from `@reown/appkit/react`
- Replace `<appkit-button />` in the disconnected prompt with a larger styled `<Button>`
- Matches the existing red accent design, with hover/press animations

### appkit.d.ts
- Removed `appkit-button` and `appkit-network-button` type declarations (no longer used)

## Verification
- `tsc --noEmit` passes cleanly
- No references to `appkit-button` remain in source files
- All styling uses Chakra UI props consistent with the existing design system