### PR TITLE
fix: guard-main workflow — allow PR merges, block direct pushes

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -9,13 +9,25 @@ jobs:
     name: Block bot direct pushes
     runs-on: ubuntu-latest
     steps:
-      - name: Reject direct push from bot
-        if: github.actor == 'clawdmorbius'
+      - name: Check push origin
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "❌ Direct push to main by clawdmorbius is not allowed."
-          echo "Please create a PR and get CEO approval before merging."
-          exit 1
+          # Check if this commit came from a merged pull request
+          PR_COUNT=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null)] | length' 2>/dev/null || echo "0")
 
-      - name: Allow
-        if: github.actor != 'clawdmorbius'
-        run: echo "✅ Push by ${{ github.actor }} allowed."
+          if [ "$PR_COUNT" -gt "0" ]; then
+            echo "✅ Push is from a merged PR. Allowed."
+            exit 0
+          fi
+
+          # Not a PR merge — block bot direct pushes
+          if [ "${{ github.actor }}" = "clawdmorbius" ]; then
+            echo "❌ Direct push to main by clawdmorbius is not allowed."
+            echo "Please create a PR and get CEO approval before merging."
+            exit 1
+          fi
+
+          echo "✅ Push by ${{ github.actor }} allowed."
+


### PR DESCRIPTION
## Problem

The `Guard Main Branch` workflow triggers a false positive when `clawdmorbius` merges a PR into main via GitHub UI. The current check only looks at `github.actor`, which is `clawdmorbius` for both direct pushes AND PR merges.

## Fix

Use the GitHub API (`gh api .../commits/{sha}/pulls`) to check if the pushed commit is associated with a merged PR:
- **PR merge** → always allowed ✅
- **Direct push by clawdmorbius** → blocked ❌
- **Direct push by anyone else** → allowed ✅

This correctly distinguishes legitimate PR merges from unauthorized direct pushes, regardless of merge strategy (merge commit, squash, rebase).

## Testing

The workflow will self-test when this PR is merged — if it passes, the fix works.