### PR TITLE
feat: MessageFeed component with callout cards and Feed tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,9 @@ import { MessageComposer } from './components/MessageComposer'
 const DecryptMessage = lazy(() =>
   import('./components/DecryptMessage').then((m) => ({ default: m.DecryptMessage }))
 )
+const MessageFeed = lazy(() =>
+  import('./components/MessageFeed').then((m) => ({ default: m.MessageFeed }))
+)
 
 const subtlePulse = keyframes`
   0%, 100% { opacity: 0.07; }
@@ -159,6 +162,29 @@ function App() {
                     <Text>Decrypt</Text>
                   </HStack>
                 </Tab>
+                <Tab
+                  borderRadius="lg"
+                  fontWeight="700"
+                  fontSize="sm"
+                  letterSpacing="0.02em"
+                  color="whiteAlpha.400"
+                  py={2.5}
+                  transition="all 0.2s"
+                  _selected={{
+                    bg: 'rgba(72, 187, 120, 0.1)',
+                    color: 'green.300',
+                    border: '1px solid',
+                    borderColor: 'rgba(72, 187, 120, 0.25)',
+                  }}
+                  _hover={{
+                    color: 'whiteAlpha.700',
+                  }}
+                >
+                  <HStack spacing={2}>
+                    <Text fontSize="sm">📋</Text>
+                    <Text>Feed</Text>
+                  </HStack>
+                </Tab>
               </TabList>
               <TabPanels>
                 <TabPanel px={0} pt={6}>
@@ -173,6 +199,17 @@ function App() {
                     }
                   >
                     <DecryptMessage />
+                  </Suspense>
+                </TabPanel>
+                <TabPanel px={0} pt={6}>
+                  <Suspense
+                    fallback={
+                      <Center py={12}>
+                        <Spinner color="green.300" size="lg" />
+                      </Center>
+                    }
+                  >
+                    <MessageFeed />
                   </Suspense>
                 </TabPanel>
               </TabPanels>

--- a/src/components/MessageFeed.test.tsx
+++ b/src/components/MessageFeed.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChakraProvider } from '@chakra-ui/react'
+import theme from '../config/theme'
+import { MessageFeed } from './MessageFeed'
+
+// Wrap component with ChakraProvider for all tests
+function renderWithChakra(ui: React.ReactElement) {
+  return render(<ChakraProvider theme={theme}>{ui}</ChakraProvider>)
+}
+
+describe('MessageFeed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-07-17T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the feed container', () => {
+    renderWithChakra(<MessageFeed />)
+    expect(screen.getByTestId('message-feed')).toBeInTheDocument()
+  })
+
+  it('displays the feed header with "Recent Callouts"', () => {
+    renderWithChakra(<MessageFeed />)
+    expect(screen.getByText('Recent Callouts')).toBeInTheDocument()
+  })
+
+  it('renders the correct number of callout cards', () => {
+    renderWithChakra(<MessageFeed />)
+    const cards = screen.getAllByTestId('callout-card')
+    // mockCallouts has 7 entries
+    expect(cards.length).toBe(7)
+  })
+
+  it('shows the posted count badge', () => {
+    renderWithChakra(<MessageFeed />)
+    expect(screen.getByText('7 posted')).toBeInTheDocument()
+  })
+
+  it('shows truncated sender addresses', () => {
+    renderWithChakra(<MessageFeed />)
+    // vitalik.eth address: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+    // truncated: 0xd8dA…6045
+    expect(screen.getByText('0xd8dA…6045')).toBeInTheDocument()
+  })
+
+  it('shows chain badges for all represented chains', () => {
+    renderWithChakra(<MessageFeed />)
+    // Two Ethereum callouts → use getAllByText
+    expect(screen.getAllByText('Ξ Ethereum').length).toBe(2)
+    expect(screen.getByText('💜 PulseChain')).toBeInTheDocument()
+    expect(screen.getByText('🔵 Arbitrum')).toBeInTheDocument()
+    expect(screen.getByText('🟣 Polygon')).toBeInTheDocument()
+    expect(screen.getByText('🔷 Base')).toBeInTheDocument()
+    expect(screen.getByText('🟡 BSC')).toBeInTheDocument()
+  })
+
+  it('shows encrypted message placeholder for encrypted callouts', () => {
+    renderWithChakra(<MessageFeed />)
+    expect(
+      screen.getByText('Encrypted message — passphrase required to decrypt')
+    ).toBeInTheDocument()
+  })
+
+  it('shows "View TX →" links for each card', () => {
+    renderWithChakra(<MessageFeed />)
+    const txLinks = screen.getAllByText('View TX →')
+    expect(txLinks.length).toBe(7)
+  })
+
+  it('renders target address sections', () => {
+    renderWithChakra(<MessageFeed />)
+    // Each card has a "🎯 Target" label
+    const targets = screen.getAllByText('🎯 Target')
+    expect(targets.length).toBe(7)
+  })
+
+  it('renders message content for non-encrypted callouts', () => {
+    renderWithChakra(<MessageFeed />)
+    // Part of the first mock callout message
+    expect(
+      screen.getByText(/rug pull on the \$SCAM token/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders the description text', () => {
+    renderWithChakra(<MessageFeed />)
+    expect(
+      screen.getByText(/Browse on-chain callouts posted by the community/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders "caller" labels for sender identicons', () => {
+    renderWithChakra(<MessageFeed />)
+    const callerLabels = screen.getAllByText('caller')
+    expect(callerLabels.length).toBe(7)
+  })
+
+  it('renders cards sorted by newest first', () => {
+    renderWithChakra(<MessageFeed />)
+    const cards = screen.getAllByTestId('callout-card')
+    // First card should be the newest (1h ago) which is the Ethereum rug pull
+    // Verify the first card contains the newest message content
+    expect(cards[0].textContent).toContain('0xd8dA…6045')
+    // Last card should be the oldest (3 days ago) — BSC wash trading
+    expect(cards[6].textContent).toContain('🟡 BSC')
+  })
+
+  it('renders TX hash previews in card footers', () => {
+    renderWithChakra(<MessageFeed />)
+    // First callout tx hash starts with 0xabc12345 and ends with 90ab01
+    expect(screen.getByText((_, element) =>
+      element?.textContent === '0xabc12345…90ab01' && element.tagName === 'P'
+    )).toBeInTheDocument()
+  })
+
+  it('links target addresses to correct block explorers', () => {
+    renderWithChakra(<MessageFeed />)
+    // PulseChain target should link to ipfs.scan.pulsechain.com
+    const pulseTarget = screen.getByRole('link', { name: '0x9876…5432' })
+    expect(pulseTarget).toHaveAttribute(
+      'href',
+      'https://ipfs.scan.pulsechain.com/address/0x9876543210FeDcBa9876543210fEdCbA98765432'
+    )
+  })
+})

--- a/src/components/MessageFeed.tsx
+++ b/src/components/MessageFeed.tsx
@@ -1,0 +1,291 @@
+import {
+  Box,
+  VStack,
+  HStack,
+  Text,
+  Badge,
+  Link,
+  Tooltip,
+} from '@chakra-ui/react'
+import { keyframes } from '@emotion/react'
+import { mockCallouts } from '../data/mockCallouts'
+import { CHAIN_INFO, getCalloutTxUrl, getCalloutAddressUrl } from '../types/callout'
+import type { Callout } from '../types/callout'
+import { cardStyle } from '../shared/styles'
+import { SectionLabel } from '../shared/SectionLabel'
+
+/* ── Animations ──────────────────────────────────────────────── */
+
+const fadeIn = keyframes`
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+`
+
+/* ── Helpers ──────────────────────────────────────────────────── */
+
+function truncateAddress(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const now = Math.floor(Date.now() / 1000)
+  const diff = now - timestamp
+
+  if (diff < 60) return 'just now'
+  if (diff < 3600) {
+    const mins = Math.floor(diff / 60)
+    return `${mins}m ago`
+  }
+  if (diff < 86400) {
+    const hours = Math.floor(diff / 3600)
+    return `${hours}h ago`
+  }
+  if (diff < 604800) {
+    const days = Math.floor(diff / 86400)
+    return `${days}d ago`
+  }
+
+  const date = new Date(timestamp * 1000)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
+  })
+}
+
+function truncateMessage(message: string, maxLength: number = 200): string {
+  if (message.length <= maxLength) return message
+  return message.slice(0, maxLength).trimEnd() + '…'
+}
+
+/* ── CalloutCard ─────────────────────────────────────────────── */
+
+interface CalloutCardProps {
+  readonly callout: Callout
+  readonly index: number
+}
+
+function CalloutCard({ callout, index }: CalloutCardProps) {
+  const chain = CHAIN_INFO[callout.chainId]
+  const txUrl = getCalloutTxUrl(callout.chainId, callout.txHash)
+  const targetUrl = getCalloutAddressUrl(callout.chainId, callout.target)
+
+  return (
+    <Box
+      data-testid="callout-card"
+      {...cardStyle}
+      position="relative"
+      overflow="hidden"
+      transition="all 0.2s ease"
+      animation={`${fadeIn} 0.4s ease ${index * 0.06}s both`}
+      _hover={{
+        borderColor: 'rgba(220, 38, 38, 0.2)',
+        bg: 'rgba(14, 14, 30, 0.75)',
+        transform: 'translateY(-1px)',
+        boxShadow: '0 4px 24px rgba(0, 0, 0, 0.3)',
+      }}
+    >
+      {/* Top accent line */}
+      <Box
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        height="1px"
+        bgGradient="linear(to-r, transparent, rgba(220,38,38,0.3), transparent)"
+      />
+
+      {/* Header row: sender + chain + timestamp */}
+      <HStack justify="space-between" align="flex-start" mb={3} flexWrap="wrap" gap={2}>
+        <HStack spacing={2} minW={0}>
+          {/* Sender identicon */}
+          <Box
+            w="32px"
+            h="32px"
+            borderRadius="lg"
+            bg="rgba(220, 38, 38, 0.1)"
+            border="1px solid"
+            borderColor="rgba(220, 38, 38, 0.2)"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            flexShrink={0}
+          >
+            <Text fontSize="xs" fontWeight="700" color="red.400">
+              📡
+            </Text>
+          </Box>
+          <Box minW={0}>
+            <Tooltip label={callout.sender} placement="top" bg="gray.800" fontSize="xs" borderRadius="lg">
+              <Text
+                fontSize="sm"
+                fontFamily="mono"
+                fontWeight="600"
+                color="whiteAlpha.700"
+                letterSpacing="0.02em"
+              >
+                {truncateAddress(callout.sender)}
+              </Text>
+            </Tooltip>
+            <Text fontSize="10px" color="whiteAlpha.300" fontWeight="500">
+              caller
+            </Text>
+          </Box>
+        </HStack>
+
+        <HStack spacing={2} flexShrink={0}>
+          {/* Chain badge */}
+          {chain && (
+            <Badge
+              variant="subtle"
+              fontSize="9px"
+              fontWeight="700"
+              letterSpacing="0.05em"
+              borderRadius="md"
+              px={2}
+              py={0.5}
+              bg="rgba(255, 255, 255, 0.04)"
+              color="whiteAlpha.500"
+              border="1px solid"
+              borderColor="whiteAlpha.50"
+            >
+              {chain.emoji} {chain.name}
+            </Badge>
+          )}
+          {/* Timestamp */}
+          <Tooltip
+            label={new Date(callout.timestamp * 1000).toLocaleString()}
+            placement="top"
+            bg="gray.800"
+            fontSize="xs"
+            borderRadius="lg"
+          >
+            <Text fontSize="xs" color="whiteAlpha.300" fontWeight="500" whiteSpace="nowrap">
+              {formatTimeAgo(callout.timestamp)}
+            </Text>
+          </Tooltip>
+        </HStack>
+      </HStack>
+
+      {/* Target address */}
+      <Box
+        mb={3}
+        p={2.5}
+        bg="rgba(220, 38, 38, 0.04)"
+        borderRadius="lg"
+        border="1px solid"
+        borderColor="rgba(220, 38, 38, 0.1)"
+      >
+        <HStack spacing={2}>
+          <Text fontSize="10px" color="red.400" fontWeight="700" letterSpacing="0.08em" textTransform="uppercase">
+            🎯 Target
+          </Text>
+          <Tooltip label={callout.target} placement="top" bg="gray.800" fontSize="xs" borderRadius="lg">
+            <Link
+              href={targetUrl}
+              isExternal
+              fontSize="xs"
+              fontFamily="mono"
+              fontWeight="600"
+              color="red.300"
+              _hover={{ color: 'red.200', textDecoration: 'underline' }}
+              letterSpacing="0.02em"
+            >
+              {truncateAddress(callout.target)}
+            </Link>
+          </Tooltip>
+        </HStack>
+      </Box>
+
+      {/* Message preview */}
+      <Box mb={3}>
+        {callout.encrypted ? (
+          <HStack spacing={2} p={3} bg="rgba(159, 122, 234, 0.06)" borderRadius="lg" border="1px solid" borderColor="rgba(159, 122, 234, 0.15)">
+            <Text fontSize="sm">🔒</Text>
+            <Text fontSize="sm" color="purple.300" fontStyle="italic" fontWeight="500">
+              Encrypted message — passphrase required to decrypt
+            </Text>
+          </HStack>
+        ) : (
+          <Text
+            fontSize="sm"
+            color="whiteAlpha.600"
+            lineHeight="1.7"
+            noOfLines={4}
+          >
+            {truncateMessage(callout.message)}
+          </Text>
+        )}
+      </Box>
+
+      {/* Footer: tx link */}
+      <HStack justify="space-between" align="center" pt={2} borderTop="1px solid" borderColor="whiteAlpha.50">
+        <Link
+          href={txUrl}
+          isExternal
+          fontSize="xs"
+          fontWeight="600"
+          color="whiteAlpha.300"
+          letterSpacing="0.03em"
+          _hover={{ color: 'red.300', textDecoration: 'none' }}
+          transition="color 0.15s"
+        >
+          View TX →
+        </Link>
+        <Text fontSize="10px" fontFamily="mono" color="whiteAlpha.200">
+          {callout.txHash.slice(0, 10)}…{callout.txHash.slice(-6)}
+        </Text>
+      </HStack>
+    </Box>
+  )
+}
+
+/* ── MessageFeed ─────────────────────────────────────────────── */
+
+export function MessageFeed() {
+  // Sort by newest first
+  const sortedCallouts = [...mockCallouts].sort((a, b) => b.timestamp - a.timestamp)
+
+  return (
+    <VStack spacing={4} align="stretch" data-testid="message-feed">
+      {/* Feed header */}
+      <Box {...cardStyle} py={4}>
+        <HStack justify="space-between" align="center">
+          <SectionLabel icon="📋" label="Recent Callouts" accent="red.400" />
+          <Badge
+            variant="outline"
+            colorScheme="red"
+            fontSize="10px"
+            fontWeight="700"
+            borderRadius="full"
+            px={2.5}
+          >
+            {sortedCallouts.length} posted
+          </Badge>
+        </HStack>
+        <Text fontSize="xs" color="whiteAlpha.300" lineHeight="1.6" mt={1}>
+          Browse on-chain callouts posted by the community. All messages are permanently inscribed as transaction calldata.
+        </Text>
+      </Box>
+
+      {/* Callout cards */}
+      {sortedCallouts.length === 0 ? (
+        <Box {...cardStyle} textAlign="center" py={12}>
+          <Text fontSize="3xl" mb={3}>
+            🔇
+          </Text>
+          <Text fontSize="md" fontWeight="600" color="whiteAlpha.400" mb={1}>
+            No callouts yet
+          </Text>
+          <Text fontSize="sm" color="whiteAlpha.250">
+            Be the first to put a scammer on blast.
+          </Text>
+        </Box>
+      ) : (
+        sortedCallouts.map((callout, index) => (
+          <CalloutCard key={callout.id} callout={callout} index={index} />
+        ))
+      )}
+    </VStack>
+  )
+}

--- a/src/data/mockCallouts.ts
+++ b/src/data/mockCallouts.ts
@@ -1,0 +1,84 @@
+import type { Callout } from '../types/callout'
+
+/**
+ * Mock callout data for development.
+ * Will be replaced by on-chain indexer data in production.
+ */
+export const mockCallouts: readonly Callout[] = [
+  {
+    id: '0xabc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab01',
+    sender: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+    target: '0x1234567890aBcDeF1234567890AbCdEf12345678',
+    message:
+      'This address ran a rug pull on the $SCAM token. Drained 500 ETH from the LP pool after promising a "community-driven project." Do not trust any new tokens deployed by this wallet.',
+    timestamp: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
+    chainId: 1,
+    txHash: '0xabc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab01',
+    encrypted: false,
+  },
+  {
+    id: '0xdef4567890abcdef1234567890abcdef1234567890abcdef1234567890abcd02',
+    sender: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+    target: '0xaBcDeF1234567890AbCdEf1234567890aBcDeF12',
+    message:
+      'Phishing site operator. Deployed a fake Uniswap frontend at uni-swap-app[.]com that drains wallets on approval. Multiple victims confirmed. Wallet received ~120 ETH in stolen funds.',
+    timestamp: Math.floor(Date.now() / 1000) - 7200, // 2 hours ago
+    chainId: 1,
+    txHash: '0xdef4567890abcdef1234567890abcdef1234567890abcdef1234567890abcd02',
+    encrypted: false,
+  },
+  {
+    id: '0x789abcdef1234567890abcdef1234567890abcdef1234567890abcdef123403',
+    sender: '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF',
+    target: '0x9876543210FeDcBa9876543210fEdCbA98765432',
+    message:
+      'Known honeypot deployer on PulseChain. Creates tokens that can be bought but never sold. Has deployed 15+ honeypots in the last month. Associated with the @FakePulseGems account.',
+    timestamp: Math.floor(Date.now() / 1000) - 18000, // 5 hours ago
+    chainId: 369,
+    txHash: '0x789abcdef1234567890abcdef1234567890abcdef1234567890abcdef123403',
+    encrypted: false,
+  },
+  {
+    id: '0x456789abcdef1234567890abcdef1234567890abcdef1234567890abcdef0004',
+    sender: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+    target: '0xDeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEf',
+    message: '[ENCRYPTED] 🔒 This message was encrypted by the sender.',
+    timestamp: Math.floor(Date.now() / 1000) - 43200, // 12 hours ago
+    chainId: 42161,
+    txHash: '0x456789abcdef1234567890abcdef1234567890abcdef1234567890abcdef0004',
+    encrypted: true,
+  },
+  {
+    id: '0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde05',
+    sender: '0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7',
+    target: '0x5555555555555555555555555555555555555555',
+    message:
+      'Fake NFT marketplace. This contract mimics OpenSea UI but sets unlimited token approvals. Victim lost 2 Bored Apes and 5 Mutants. Contract is a proxy that can change implementation at any time.',
+    timestamp: Math.floor(Date.now() / 1000) - 86400, // 1 day ago
+    chainId: 137,
+    txHash: '0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde05',
+    encrypted: false,
+  },
+  {
+    id: '0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba987654306',
+    sender: '0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5',
+    target: '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa',
+    message:
+      'Social engineering scammer. Impersonates project team members in Discord DMs. Sends fake "verification" links. Has compromised at least 3 community moderator accounts.',
+    timestamp: Math.floor(Date.now() / 1000) - 172800, // 2 days ago
+    chainId: 8453,
+    txHash: '0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba987654306',
+    encrypted: false,
+  },
+  {
+    id: '0x1111111111111111111111111111111111111111111111111111111111111107',
+    sender: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    target: '0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb',
+    message:
+      'Wash trading bot operator on BSC DEXes. Inflates volume on new tokens to bait retail traders, then dumps. Connected to the "100x Gem Calls" Telegram group.',
+    timestamp: Math.floor(Date.now() / 1000) - 259200, // 3 days ago
+    chainId: 56,
+    txHash: '0x1111111111111111111111111111111111111111111111111111111111111107',
+    encrypted: false,
+  },
+] as const

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,6 +5,9 @@
  * TextEncoder/TextDecoder and crypto.subtle (Web Crypto API).
  */
 
+// Extend Vitest matchers with jest-dom (toBeInTheDocument, etc.)
+import '@testing-library/jest-dom/vitest'
+
 // Ensure crypto.subtle is available for encryption tests.
 // happy-dom ships with a globalThis.crypto that includes subtle.
 if (typeof globalThis.crypto === 'undefined') {

--- a/src/types/callout.test.ts
+++ b/src/types/callout.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { CHAIN_INFO, getCalloutTxUrl, getCalloutAddressUrl } from './callout'
+
+describe('CHAIN_INFO', () => {
+  it('contains all expected chains', () => {
+    expect(CHAIN_INFO[1]).toBeDefined()       // Ethereum
+    expect(CHAIN_INFO[369]).toBeDefined()     // PulseChain
+    expect(CHAIN_INFO[137]).toBeDefined()     // Polygon
+    expect(CHAIN_INFO[42161]).toBeDefined()   // Arbitrum
+    expect(CHAIN_INFO[10]).toBeDefined()      // Optimism
+    expect(CHAIN_INFO[8453]).toBeDefined()    // Base
+    expect(CHAIN_INFO[56]).toBeDefined()      // BSC
+  })
+
+  it('each chain has required fields', () => {
+    for (const [, info] of Object.entries(CHAIN_INFO)) {
+      expect(info.name).toBeTruthy()
+      expect(info.explorerUrl).toMatch(/^https:\/\//)
+      expect(info.color).toMatch(/^#/)
+      expect(info.emoji).toBeTruthy()
+    }
+  })
+})
+
+describe('getCalloutTxUrl', () => {
+  it('returns correct Ethereum TX URL', () => {
+    const url = getCalloutTxUrl(1, '0xabc123')
+    expect(url).toBe('https://etherscan.io/tx/0xabc123')
+  })
+
+  it('returns correct PulseChain TX URL', () => {
+    const url = getCalloutTxUrl(369, '0xdef456')
+    expect(url).toBe('https://ipfs.scan.pulsechain.com/tx/0xdef456')
+  })
+
+  it('falls back to etherscan for unknown chain', () => {
+    const url = getCalloutTxUrl(99999, '0x123')
+    expect(url).toBe('https://etherscan.io/tx/0x123')
+  })
+})
+
+describe('getCalloutAddressUrl', () => {
+  it('returns correct Ethereum address URL', () => {
+    const url = getCalloutAddressUrl(1, '0xabc123')
+    expect(url).toBe('https://etherscan.io/address/0xabc123')
+  })
+
+  it('returns correct Base address URL', () => {
+    const url = getCalloutAddressUrl(8453, '0xdef456')
+    expect(url).toBe('https://basescan.org/address/0xdef456')
+  })
+
+  it('falls back to etherscan for unknown chain', () => {
+    const url = getCalloutAddressUrl(99999, '0x123')
+    expect(url).toBe('https://etherscan.io/address/0x123')
+  })
+})

--- a/src/types/callout.ts
+++ b/src/types/callout.ts
@@ -1,0 +1,55 @@
+/**
+ * Represents a single on-chain callout message.
+ * This type will be shared between mock data and future indexer integration.
+ */
+export interface Callout {
+  /** Unique identifier (tx hash) */
+  readonly id: string
+  /** Sender wallet address */
+  readonly sender: string
+  /** Target (scammer) wallet address */
+  readonly target: string
+  /** Decoded message content */
+  readonly message: string
+  /** Unix timestamp (seconds) */
+  readonly timestamp: number
+  /** Chain ID where the callout was posted */
+  readonly chainId: number
+  /** Transaction hash */
+  readonly txHash: string
+  /** Whether the message is encrypted */
+  readonly encrypted: boolean
+}
+
+/** Chain metadata for display */
+export interface ChainInfo {
+  readonly name: string
+  readonly explorerUrl: string
+  readonly color: string
+  readonly emoji: string
+}
+
+/** Supported chain info lookup */
+export const CHAIN_INFO: Record<number, ChainInfo> = {
+  1: { name: 'Ethereum', explorerUrl: 'https://etherscan.io', color: '#627eea', emoji: 'Ξ' },
+  369: { name: 'PulseChain', explorerUrl: 'https://ipfs.scan.pulsechain.com', color: '#00ff88', emoji: '💜' },
+  137: { name: 'Polygon', explorerUrl: 'https://polygonscan.com', color: '#8247e5', emoji: '🟣' },
+  42161: { name: 'Arbitrum', explorerUrl: 'https://arbiscan.io', color: '#28a0f0', emoji: '🔵' },
+  10: { name: 'Optimism', explorerUrl: 'https://optimistic.etherscan.io', color: '#ff0420', emoji: '🔴' },
+  8453: { name: 'Base', explorerUrl: 'https://basescan.org', color: '#0052ff', emoji: '🔷' },
+  56: { name: 'BSC', explorerUrl: 'https://bscscan.com', color: '#f3ba2f', emoji: '🟡' },
+}
+
+/** Get the block explorer TX URL for a given chain and tx hash */
+export function getCalloutTxUrl(chainId: number, txHash: string): string {
+  const chain = CHAIN_INFO[chainId]
+  const base = chain?.explorerUrl ?? 'https://etherscan.io'
+  return `${base}/tx/${txHash}`
+}
+
+/** Get the block explorer address URL for a given chain and address */
+export function getCalloutAddressUrl(chainId: number, address: string): string {
+  const chain = CHAIN_INFO[chainId]
+  const base = chain?.explorerUrl ?? 'https://etherscan.io'
+  return `${base}/address/${address}`
+}


### PR DESCRIPTION
## Summary

Adds a **MessageFeed UI** — a browsable feed of on-chain callouts posted by the community.

### What's new
- **`Callout` type** (`src/types/callout.ts`) — shared data model with chain info lookup, explorer URL helpers
- **Mock data** (`src/data/mockCallouts.ts`) — 7 realistic callouts across Ethereum, PulseChain, Polygon, Arbitrum, Base, BSC
- **`MessageFeed` component** (`src/components/MessageFeed.tsx`) — animated cards with:
  - Sender identicons + truncated addresses
  - Chain badges (emoji + name)
  - Target address links (to correct block explorer per chain)
  - Message previews (truncated, with encrypted placeholder for encrypted callouts)
  - Relative timestamps (just now, 2h ago, etc.)
  - TX hash links to block explorers
  - Staggered fade-in animations
  - Hover states with subtle glow effects
- **Feed tab** in `App.tsx` — third tab alongside Send Callout / Decrypt
- **`@testing-library/jest-dom`** matchers added to test setup
- **23 new tests** (15 component + 8 type/helper) — all pass
- **`tsc --noEmit`** — zero type errors

### Screenshots

#### Feed Tab (new)
Shows all 7 mock callouts sorted newest first, with chain badges, targets, message previews, encrypted placeholders, and TX links:

![Feed Tab](https://github.com/user-attachments/assets/placeholder-feed-tab)

#### Send Tab (existing, with new tab bar)
Tab bar now shows 3 tabs: Send Callout | Decrypt | Feed:

![Send Tab](https://github.com/user-attachments/assets/placeholder-send-tab)

### Test Results
```
✓ src/components/MessageFeed.test.tsx (15 tests)
✓ src/types/callout.test.ts (8 tests)
All 86 tests pass across 7 test files
tsc --noEmit: clean
```

### Files Changed
| File | Change |
|---|---|
| `src/types/callout.ts` | New — Callout type, ChainInfo, explorer URL helpers |
| `src/data/mockCallouts.ts` | New — 7 mock callouts |
| `src/components/MessageFeed.tsx` | New — MessageFeed + CalloutCard components |
| `src/components/MessageFeed.test.tsx` | New — 15 component tests |
| `src/types/callout.test.ts` | New — 8 type/helper tests |
| `src/test/setup.ts` | Modified — added jest-dom matchers import |
| `src/App.tsx` | Modified — added Feed tab + lazy-loaded MessageFeed |
