### PR TITLE
fix: feed shows callouts FROM address (sent messages)

### DIFF
--- a/src/components/MessageFeed.test.tsx
+++ b/src/components/MessageFeed.test.tsx
@@ -35,20 +35,20 @@ describe('MessageFeed', () => {
 
   it('renders the search interface', () => {
     renderFeed()
-    expect(screen.getByLabelText('Target address to search')).toBeInTheDocument()
-    expect(screen.getByLabelText('Search for callouts to this address')).toBeInTheDocument()
+    expect(screen.getByLabelText('Sender address to search')).toBeInTheDocument()
+    expect(screen.getByLabelText('Search for callouts from this address')).toBeInTheDocument()
   })
 
   it('shows initial empty state before search', () => {
     renderFeed()
     expect(screen.getByText('Search for callouts')).toBeInTheDocument()
-    expect(screen.getByText('Enter an address above to find on-chain messages sent to it.')).toBeInTheDocument()
+    expect(screen.getByText('Enter an address to see the callout messages it has sent.')).toBeInTheDocument()
   })
 
   it('validates address before searching', async () => {
     renderFeed()
-    const input = screen.getByLabelText('Target address to search')
-    const button = screen.getByLabelText('Search for callouts to this address')
+    const input = screen.getByLabelText('Sender address to search')
+    const button = screen.getByLabelText('Search for callouts from this address')
 
     fireEvent.change(input, { target: { value: 'not-an-address' } })
     fireEvent.click(button)
@@ -78,8 +78,8 @@ describe('MessageFeed', () => {
     vi.mocked(explorer.transactionsToCallouts).mockReturnValue(mockCallouts)
 
     renderFeed()
-    const input = screen.getByLabelText('Target address to search')
-    const button = screen.getByLabelText('Search for callouts to this address')
+    const input = screen.getByLabelText('Sender address to search')
+    const button = screen.getByLabelText('Search for callouts from this address')
 
     fireEvent.change(input, { target: { value: '0x2222222222222222222222222222222222222222' } })
     fireEvent.click(button)
@@ -99,8 +99,8 @@ describe('MessageFeed', () => {
     vi.mocked(explorer.transactionsToCallouts).mockReturnValue([])
 
     renderFeed()
-    const input = screen.getByLabelText('Target address to search')
-    const button = screen.getByLabelText('Search for callouts to this address')
+    const input = screen.getByLabelText('Sender address to search')
+    const button = screen.getByLabelText('Search for callouts from this address')
 
     fireEvent.change(input, { target: { value: '0x2222222222222222222222222222222222222222' } })
     fireEvent.click(button)
@@ -116,8 +116,8 @@ describe('MessageFeed', () => {
     )
 
     renderFeed()
-    const input = screen.getByLabelText('Target address to search')
-    const button = screen.getByLabelText('Search for callouts to this address')
+    const input = screen.getByLabelText('Sender address to search')
+    const button = screen.getByLabelText('Search for callouts from this address')
 
     fireEvent.change(input, { target: { value: '0x2222222222222222222222222222222222222222' } })
     fireEvent.click(button)
@@ -129,7 +129,7 @@ describe('MessageFeed', () => {
 
   it('supports Enter key to search', () => {
     renderFeed()
-    const input = screen.getByLabelText('Target address to search')
+    const input = screen.getByLabelText('Sender address to search')
 
     fireEvent.change(input, { target: { value: '0x2222222222222222222222222222222222222222' } })
     fireEvent.keyDown(input, { key: 'Enter' })

--- a/src/components/MessageFeed.tsx
+++ b/src/components/MessageFeed.tsx
@@ -325,7 +325,7 @@ export function MessageFeed() {
       <Box {...cardStyle} py={4}>
         <SectionLabel icon="📋" label="Callout Feed" accent="red.400" />
         <Text fontSize="xs" color="whiteAlpha.300" lineHeight="1.6" mt={1} mb={4}>
-          Enter an address to see on-chain callout messages sent to it. Scans PulseChain transactions and decodes calldata as text.
+          See callout messages sent from an address. Connect your wallet to prove you're the sender.
         </Text>
 
         {/* Connected wallet shortcut — disappears once populated */}
@@ -349,7 +349,7 @@ export function MessageFeed() {
             }}
             transition="color 0.15s"
           >
-            Select Connected: {truncateAddress(connectedAddress)}
+            Use My Wallet: {truncateAddress(connectedAddress)}
           </Button>
         )}
 
@@ -357,16 +357,16 @@ export function MessageFeed() {
         <HStack spacing={2}>
           <InputGroup flex={1}>
             <InputLeftElement h="44px" pointerEvents="none">
-              <Text fontSize="sm" color="whiteAlpha.300">🎯</Text>
+              <Text fontSize="sm" color="whiteAlpha.300">📤</Text>
             </InputLeftElement>
             <Input
-              placeholder="0x… target address"
+              placeholder="0x… sender address"
               value={addressInput}
               onChange={(e) => setAddressInput(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleSearch()
               }}
-              aria-label="Target address to search"
+              aria-label="Sender address to search"
               fontFamily="mono"
               fontSize="sm"
               h="44px"
@@ -396,7 +396,7 @@ export function MessageFeed() {
             isLoading={isLoading}
             loadingText="Scanning..."
             isDisabled={!addressInput.trim()}
-            aria-label="Search for callouts to this address"
+            aria-label="Search for callouts from this address"
             _hover={{
               bg: 'rgba(220, 38, 38, 0.25)',
               transform: 'translateY(-1px)',
@@ -448,7 +448,7 @@ export function MessageFeed() {
         <HStack justify="space-between" px={1}>
           <HStack spacing={2}>
             <Text fontSize="xs" color="whiteAlpha.300">
-              Showing callouts to
+              Showing callouts from
             </Text>
             <Text fontSize="xs" fontFamily="mono" color="red.300" fontWeight="600">
               {truncateAddress(searchedAddress)}
@@ -512,7 +512,7 @@ export function MessageFeed() {
             Search for callouts
           </Text>
           <Text fontSize="sm" color="whiteAlpha.250">
-            Enter an address above to find on-chain messages sent to it.
+            Enter an address to see the callout messages it has sent.
           </Text>
         </Box>
       )}

--- a/src/services/explorer.ts
+++ b/src/services/explorer.ts
@@ -54,7 +54,7 @@ export interface BlockScoutTxListResponse {
 /* ── Fetch helpers ───────────────────────────────────────── */
 
 /**
- * Fetch transactions sent TO a given address on PulseChain.
+ * Fetch transactions sent FROM a given address on PulseChain.
  * Returns the raw BlockScout response with pagination support.
  */
 export async function fetchAddressTransactions(
@@ -62,7 +62,7 @@ export async function fetchAddressTransactions(
   nextPageParams?: BlockScoutNextPage | null,
 ): Promise<BlockScoutTxListResponse> {
   const url = new URL(`${BLOCKSCOUT_BASE}/addresses/${address}/transactions`)
-  url.searchParams.set('type', 'to')
+  url.searchParams.set('type', 'from')
 
   if (nextPageParams) {
     url.searchParams.set('block_number', String(nextPageParams.block_number))


### PR DESCRIPTION
Fixes the feed direction per CEO feedback. The feed should show messages **sent from** an address, not received by it.

**Why:** When a hacker receives a callout, they can verify the sender owns the wallet by checking the feed — if the message shows up in the feed for that sender's address, it proves authorship.

**Changes:**
- BlockScout API now fetches `type=from` instead of `type=to`
- Copy updated throughout: 'sender address', 'callouts from', 'Use My Wallet'
- Tests updated

All 78 tests pass.