### PR TITLE
fix: remove negative margins causing Connect Wallet button overflow

### DIFF
--- a/packages/ui/src/components/MessageComposer.tsx
+++ b/packages/ui/src/components/MessageComposer.tsx
@@ -542,11 +542,7 @@ export function MessageComposer() {
 
         {/* Connect Wallet button - at bottom of Compose Message card when not connected */}
         {!isConnected && (
-          <Box
-            mx={{ base: -4, md: -6 }}
-            mt={4}
-            mb={{ base: -4, md: -6 }}
-          >
+          <Box mt={4}>
             <Button
               size="lg"
               width="full"


### PR DESCRIPTION
## Bug
The Connect Wallet button on callout.city was misaligned, overflowing its container boundaries.

## Root Cause
The button wrapper used negative margins (`mx: -4/-6`, `mb: -4/-6`) that were unnecessary because the button is positioned **outside** the padded VStack, directly inside the outer Box which has **no padding**. The negative margins pulled the button beyond the card boundaries.

## Changes
- Removed `mx={{ base: -4, md: -6 }}` from button wrapper
- Removed `mb={{ base: -4, md: -6 }}` from button wrapper
- Kept `mt={4}` for proper spacing from content above
- Button now aligns flush with card edges via existing `width="full"`

## Testing
- ✅ Build passed: `yarn build:ui`
- ✅ All tests passing: 130 tests in @callout/ui, 100 tests in @callout/shared
- Visual alignment should be verified on callout.city

## Files Changed
- `packages/ui/src/components/MessageComposer.tsx` (1 file, 1 insertion, 5 deletions)

Fixes button misalignment issue.